### PR TITLE
Fix URL on user_guide.rst

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -40,7 +40,7 @@ Sending/Recieving messages
 ==========================
 
 Let's request profile of the currently logged on user. We only need the account id.
-If need to convert from steam id or any other format see `SteamID <http://valvepython.github.io/steam/api/steam.steamid.html>`_.
+If need to convert from steam id or any other format see `SteamID <https://steam.readthedocs.io/en/latest/api/steam.steamid.html>`_.
 
 .. code:: python
 


### PR DESCRIPTION
There may be other URLS that need fixing (which I have not checked) but this is one of them, noticed whilst trying to interface with "*request_live_game_for_user*"

If required I can look through the documentation and see if there are any others that need to be changed as well.